### PR TITLE
Added tests for routing and unrouting with multiple routes distinguished only by extension

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/nukleus/control/route/server/multiple.authorizations/controller.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/control/route/server/multiple.authorizations/controller.rpt
@@ -15,8 +15,7 @@
 # under the License.
 #
 
-property newServerConnectRef1 ${nuklei:newReferenceId()} # external scope
-property newServerConnectRef2 ${nuklei:newReferenceId()} # external scope
+property newServerConnectRef ${nuklei:newReferenceId()} # external scope
 
 property route1Authorization 0x0001_000000000000L
 property route2Authorization 0x0001_000000000001L
@@ -37,7 +36,7 @@ write [0x00]
 write [0x06] "source"
 write 0L
 write [0x06] "target"
-write ${newServerConnectRef1}
+write ${newServerConnectRef}
 write ${route1Authorization}
 write 0
 write flush
@@ -52,7 +51,7 @@ write [0x00]
 write [0x06] "source"
 write ${newServerAcceptRef}
 write [0x06] "target"
-write ${newServerConnectRef2}
+write ${newServerConnectRef}
 write ${route2Authorization}
 write 0
 write flush

--- a/src/main/scripts/org/reaktivity/specification/nukleus/control/route/server/multiple.extensions/controller.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/control/route/server/multiple.extensions/controller.rpt
@@ -15,8 +15,7 @@
 # under the License.
 #
 
-property newServerConnectRef1 ${nuklei:newReferenceId()} # external scope
-property newServerConnectRef2 ${nuklei:newReferenceId()} # external scope
+property newServerConnectRef ${nuklei:newReferenceId()} # external scope
 
 property route1Extension "ext1"
 property route2Extension "ext2"
@@ -37,7 +36,7 @@ write [0x00]
 write [0x06] "source"
 write 0L
 write [0x06] "target"
-write ${newServerConnectRef1}
+write ${newServerConnectRef}
 write 0L
 write ${route1Extension}
 write flush
@@ -52,7 +51,7 @@ write [0x00]
 write [0x06] "source"
 write ${newServerAcceptRef}
 write [0x06] "target"
-write ${newServerConnectRef2}
+write ${newServerConnectRef}
 write 0L
 write ${route2Extension}
 write flush

--- a/src/main/scripts/org/reaktivity/specification/nukleus/control/route/server/multiple.extensions/controller.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/control/route/server/multiple.extensions/controller.rpt
@@ -1,0 +1,67 @@
+
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newServerConnectRef1 ${nuklei:newReferenceId()} # external scope
+property newServerConnectRef2 ${nuklei:newReferenceId()} # external scope
+
+property route1Extension "ext1"
+property route2Extension "ext2"
+
+property nukleiRME00C ${nuklei:directory("target/nukleus-itests").controlCapacity(1024, 1024)}
+
+property controlRME00C ${nukleiRME00C.control("example")}
+
+connect "agrona://stream/bidirectional"
+        option agrona:reader ${agrona:broadcastReceiver(controlRME00C.controller)}
+        option agrona:writer ${agrona:manyToOneWriter(controlRME00C.nukleus)}
+
+connected
+
+write 0x00000001
+write ${controlRME00C.nextCorrelationId()}
+write [0x00]
+write [0x06] "source"
+write 0L
+write [0x06] "target"
+write ${newServerConnectRef1}
+write 0L
+write ${route1Extension}
+write flush
+
+read 0x40000001
+read ${controlRME00C.correlationId()}
+read (long:newServerAcceptRef)
+
+write 0x00000001
+write ${controlRME00C.nextCorrelationId()}
+write [0x00]
+write [0x06] "source"
+write ${newServerAcceptRef}
+write [0x06] "target"
+write ${newServerConnectRef2}
+write 0L
+write ${route2Extension}
+write flush
+
+read 0x40000001
+read ${controlRME00C.correlationId()}
+read  ${newServerAcceptRef}
+
+read notify ROUTED_SERVER
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/control/route/server/multiple.extensions/nukleus.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/control/route/server/multiple.extensions/nukleus.rpt
@@ -1,0 +1,63 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property nukleiRME00N ${nuklei:directory("target/nukleus-itests").controlCapacity(1024, 1024)}
+
+property controlRME00N ${nukleiRME00N.controlNew("example")}
+
+property newServerAcceptRefRME00N ${nuklei:newReferenceId()}
+
+property route1Extension "ext1"
+property route2Extension "ext2"
+
+connect "agrona://stream/bidirectional"
+        option agrona:reader ${agrona:manyToOneReader(controlRME00N.nukleus)}
+        option agrona:writer ${agrona:broadcastTransmitter(controlRME00N.controller)}
+
+connected
+
+read 0x00000001
+read (long:correlationId1RME00N)
+read [0x00]
+read [0x06] "source"
+read 0L
+read [0x06] "target"
+read [0..8] # server connect ref
+read [0..8] # authorization
+read ${route1Extension}
+
+write 0x40000001
+write ${correlationId1RME00N}
+write ${newServerAcceptRefRME00N}
+write flush
+
+read 0x00000001
+read (long:correlationId2RME00N)
+read [0x00]
+read [0x06] "source"
+read ${newServerAcceptRefRME00N}
+read [0x06] "target"
+read [0..8] # server connect ref
+read [0..8] # authorization
+read ${route2Extension}
+
+write 0x40000001
+write ${correlationId2RME00N}
+write ${newServerAcceptRefRME00N}
+write flush
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/control/unroute/server/multiple.authorizations/controller.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/control/unroute/server/multiple.authorizations/controller.rpt
@@ -15,8 +15,7 @@
 #
 
 property newServerAcceptRef ${nuklei:newReferenceId()} # external scope
-property newServerConnectRef1 ${nuklei:newReferenceId()} # external scope
-property newServerConnectRef2 ${nuklei:newReferenceId()} # external scope
+property newServerConnectRef ${nuklei:newReferenceId()} # external scope
 
 property route1Authorization 0x0001_000000000000L
 property route2Authorization 0x0002_000000000000L
@@ -39,7 +38,7 @@ write [0x00]
 write [0x06] "source"
 write ${newServerAcceptRef}
 write [0x06] "target"
-write ${newServerConnectRef1}
+write ${newServerConnectRef}
 write ${route1Authorization}
 write 0
 write flush
@@ -53,7 +52,7 @@ write [0x00]
 write [0x06] "source"
 write ${newServerAcceptRef}
 write [0x06] "target"
-write ${newServerConnectRef2}
+write ${newServerConnectRef}
 write ${route2Authorization}
 write 0
 write flush

--- a/src/main/scripts/org/reaktivity/specification/nukleus/control/unroute/server/multiple.extensions/controller.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/control/unroute/server/multiple.extensions/controller.rpt
@@ -15,8 +15,7 @@
 #
 
 property newServerAcceptRef ${nuklei:newReferenceId()} # external scope
-property newServerConnectRef1 ${nuklei:newReferenceId()} # external scope
-property newServerConnectRef2 ${nuklei:newReferenceId()} # external scope
+property newServerConnectRef ${nuklei:newReferenceId()} # external scope
 
 property route1Extension "ext1"
 property route2Extension "ext2"
@@ -39,7 +38,7 @@ write [0x00]
 write [0x06] "source"
 write ${newServerAcceptRef}
 write [0x06] "target"
-write ${newServerConnectRef1}
+write ${newServerConnectRef}
 write 0L
 write ${route1Extension}
 write flush
@@ -53,7 +52,7 @@ write [0x00]
 write [0x06] "source"
 write ${newServerAcceptRef}
 write [0x06] "target"
-write ${newServerConnectRef2}
+write ${newServerConnectRef}
 write 0L
 write ${route2Extension}
 write flush

--- a/src/main/scripts/org/reaktivity/specification/nukleus/control/unroute/server/multiple.extensions/controller.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/control/unroute/server/multiple.extensions/controller.rpt
@@ -1,0 +1,65 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newServerAcceptRef ${nuklei:newReferenceId()} # external scope
+property newServerConnectRef1 ${nuklei:newReferenceId()} # external scope
+property newServerConnectRef2 ${nuklei:newReferenceId()} # external scope
+
+property route1Extension "ext1"
+property route2Extension "ext2"
+
+property nukleiURME00C ${nuklei:directory("target/nukleus-itests").controlCapacity(1024, 1024)}
+
+property controlURME00C ${nukleiURME00C.control("example")}
+
+
+connect await ROUTED_SERVER
+        "agrona://stream/bidirectional"
+        option agrona:reader ${agrona:broadcastReceiver(controlURME00C.controller)}
+        option agrona:writer ${agrona:manyToOneWriter(controlURME00C.nukleus)}
+
+connected
+
+write 0x00000002
+write ${controlURME00C.nextCorrelationId()}
+write [0x00]
+write [0x06] "source"
+write ${newServerAcceptRef}
+write [0x06] "target"
+write ${newServerConnectRef1}
+write 0L
+write ${route1Extension}
+write flush
+
+read 0x40000002
+read ${controlURME00C.correlationId()}
+
+write 0x00000002
+write ${controlURME00C.nextCorrelationId()}
+write [0x00]
+write [0x06] "source"
+write ${newServerAcceptRef}
+write [0x06] "target"
+write ${newServerConnectRef2}
+write 0L
+write ${route2Extension}
+write flush
+
+read 0x40000002
+read ${controlURME00C.correlationId()}
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/control/unroute/server/multiple.extensions/nukleus.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/control/unroute/server/multiple.extensions/nukleus.rpt
@@ -1,0 +1,57 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property nukleiURME00N ${nuklei:directory("target/nukleus-itests").controlCapacity(1024, 1024)}
+
+property controlURME00N ${nukleiURME00N.controlNew("example")}
+
+connect await ROUTED_SERVER
+        "agrona://stream/bidirectional"
+        option agrona:reader ${agrona:manyToOneReader(controlURME00N.nukleus)}
+        option agrona:writer ${agrona:broadcastTransmitter(controlURME00N.controller)}
+
+connected
+
+read 0x00000002
+read (long:correlationId1URME00N)
+read [0x00]
+read [0x06] "source"
+read (long:serverAcceptRefURME00N)
+read [0x06] "target"
+read [0..8]
+read [0..8] # authorization
+read ${route1Extension}
+
+write 0x40000002
+write ${correlationId1URME00N}
+write flush
+
+read 0x00000002
+read (long:correlationId2URME00N)
+read [0x00]
+read [0x06] "source"
+read (long:serverAcceptRefURME00N)
+read [0x06] "target"
+read [0..8]
+read [0..8] # authorization
+read ${route2Extension}
+
+write 0x40000002
+write ${correlationId2URME00N}
+write flush
+
+close
+closed

--- a/src/test/java/org/reaktivity/specification/nukleus/control/ControlIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/control/ControlIT.java
@@ -110,6 +110,16 @@ public class ControlIT
 
     @Test
     @Specification({
+        "route/server/multiple.extensions/nukleus",
+        "route/server/multiple.extensions/controller"
+    })
+    public void shouldRouteServerByExtension() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "route/client/nukleus",
         "route/client/controller",
         "unroute/client/nukleus",
@@ -176,7 +186,19 @@ public class ControlIT
         "unroute/server/multiple.authorizations/nukleus",
         "unroute/server/multiple.authorizations/controller"
     })
-    public void shouldUnrouteServerMultipleAuthorizations() throws Exception
+    public void shouldUnrouteServerByAuthorization() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "route/server/multiple.extensions/nukleus",
+        "route/server/multiple.extensions/controller",
+        "unroute/server/multiple.extensions/nukleus",
+        "unroute/server/multiple.extensions/controller"
+    })
+    public void shouldUnrouteServerByExtension() throws Exception
     {
         k3po.finish();
     }


### PR DESCRIPTION
Also enhanced the similar existing multiple.authorizations scripts to distinguish only by authorization (make connect ref the same).