### PR TITLE
Added capabilities functionality to core.idl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <junit.version>4.12</junit.version>
     <k3po.version>3.0.0-alpha-101</k3po.version>
     <k3po.nukleus.ext.version>0.44</k3po.nukleus.ext.version>
-    <nukleus.plugin.version>0.32</nukleus.plugin.version>
+    <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <junit.version>4.12</junit.version>
     <k3po.version>3.0.0-alpha-101</k3po.version>
     <k3po.nukleus.ext.version>0.44</k3po.nukleus.ext.version>
-    <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
+    <nukleus.plugin.version>0.39</nukleus.plugin.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <agrona.version>0.9.35</agrona.version>
     <junit.version>4.12</junit.version>
     <k3po.version>3.0.0-alpha-101</k3po.version>
-    <k3po.nukleus.ext.version>0.44</k3po.nukleus.ext.version>
+    <k3po.nukleus.ext.version>develop-SNAPSHOT</k3po.nukleus.ext.version>
     <nukleus.plugin.version>0.39</nukleus.plugin.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/specification/nukleus/CoreFunctions.java
+++ b/src/main/java/org/reaktivity/specification/nukleus/CoreFunctions.java
@@ -20,7 +20,6 @@ import static java.util.Optional.ofNullable;
 import static org.agrona.BitUtil.SIZE_OF_BYTE;
 import static org.agrona.BitUtil.SIZE_OF_SHORT;
 
-import java.nio.ByteBuffer;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 

--- a/src/main/java/org/reaktivity/specification/nukleus/CoreFunctions.java
+++ b/src/main/java/org/reaktivity/specification/nukleus/CoreFunctions.java
@@ -31,33 +31,34 @@ import org.kaazing.k3po.lang.el.Function;
 import org.kaazing.k3po.lang.el.spi.FunctionMapperSpi;
 import org.reaktivity.specification.nukleus.internal.types.String16FW;
 import org.reaktivity.specification.nukleus.internal.types.StringFW;
+import org.reaktivity.specification.nukleus.internal.types.control.Capability;
 
 public final class CoreFunctions
 {
-    enum Capability
-    {
-        CHALLENGE(0x01);
-
-        final int capability;
-
-        Capability(int bitPos)
-        {
-            capability = bitPos;
-        }
-
-        public static int of(
-            String name,
-            String... optionalNames)
-        {
-            int capabilityMask = 0x00;
-            capabilityMask |= Capability.valueOf(name).capability;
-            for (int i = 0; i < optionalNames.length; i++)
-            {
-                capabilityMask |= Capability.valueOf(optionalNames[i]).capability;
-            }
-            return capabilityMask;
-        }
-    }
+//    enum Capability
+//    {
+//        CHALLENGE(0x01);
+//
+//        final int capability;
+//
+//        Capability(int bitPos)
+//        {
+//            capability = bitPos;
+//        }
+//
+//        public static int of(
+//            String name,
+//            String... optionalNames)
+//        {
+//            int capabilityMask = 0x00;
+//            capabilityMask |= Capability.valueOf(name).capability;
+//            for (int i = 0; i < optionalNames.length; i++)
+//            {
+//                capabilityMask |= Capability.valueOf(optionalNames[i]).capability;
+//            }
+//            return capabilityMask;
+//        }
+//    }
 
     private static final ThreadLocal<StringFW.Builder> STRING_RW = ThreadLocal.withInitial(StringFW.Builder::new);
     private static final ThreadLocal<String16FW.Builder> STRING16_RW = ThreadLocal.withInitial(String16FW.Builder::new);
@@ -112,11 +113,24 @@ public final class CoreFunctions
         String capability,
         String... optionalCapabilities)
     {
-        int capabilities = Capability.of(capability, optionalCapabilities);
+        int capabilities = of(capability, optionalCapabilities);
 
         ByteBuffer bb = ByteBuffer.allocate(1);
         bb.put((byte) capabilities);
         return bb.array();
+    }
+
+    public static int of(
+        String name,
+        String... optionalNames)
+    {
+        int capabilityMask = 0x00;
+        capabilityMask |= 1 << Capability.valueOf(name).ordinal();
+        for (int i = 0; i < optionalNames.length; i++)
+        {
+            capabilityMask |= 1 << Capability.valueOf(optionalNames[i]).ordinal();
+        }
+        return capabilityMask;
     }
 
     public static class Mapper extends FunctionMapperSpi.Reflective

--- a/src/main/java/org/reaktivity/specification/nukleus/CoreFunctions.java
+++ b/src/main/java/org/reaktivity/specification/nukleus/CoreFunctions.java
@@ -35,31 +35,6 @@ import org.reaktivity.specification.nukleus.internal.types.control.Capability;
 
 public final class CoreFunctions
 {
-//    enum Capability
-//    {
-//        CHALLENGE(0x01);
-//
-//        final int capability;
-//
-//        Capability(int bitPos)
-//        {
-//            capability = bitPos;
-//        }
-//
-//        public static int of(
-//            String name,
-//            String... optionalNames)
-//        {
-//            int capabilityMask = 0x00;
-//            capabilityMask |= Capability.valueOf(name).capability;
-//            for (int i = 0; i < optionalNames.length; i++)
-//            {
-//                capabilityMask |= Capability.valueOf(optionalNames[i]).capability;
-//            }
-//            return capabilityMask;
-//        }
-//    }
-
     private static final ThreadLocal<StringFW.Builder> STRING_RW = ThreadLocal.withInitial(StringFW.Builder::new);
     private static final ThreadLocal<String16FW.Builder> STRING16_RW = ThreadLocal.withInitial(String16FW.Builder::new);
 

--- a/src/main/java/org/reaktivity/specification/nukleus/CoreFunctions.java
+++ b/src/main/java/org/reaktivity/specification/nukleus/CoreFunctions.java
@@ -95,7 +95,7 @@ public final class CoreFunctions
         return bb.array();
     }
 
-    public static int of(
+    private static int of(
         String name,
         String... optionalNames)
     {

--- a/src/main/java/org/reaktivity/specification/nukleus/CoreFunctions.java
+++ b/src/main/java/org/reaktivity/specification/nukleus/CoreFunctions.java
@@ -84,22 +84,18 @@ public final class CoreFunctions
     }
 
     @Function
-    public static byte[] capabilities(
+    public static byte capabilities(
         String capability,
         String... optionalCapabilities)
     {
-        int capabilities = of(capability, optionalCapabilities);
-
-        ByteBuffer bb = ByteBuffer.allocate(1);
-        bb.put((byte) capabilities);
-        return bb.array();
+        return of(capability, optionalCapabilities);
     }
 
-    private static int of(
+    private static byte of(
         String name,
         String... optionalNames)
     {
-        int capabilityMask = 0x00;
+        byte capabilityMask = 0x00;
         capabilityMask |= 1 << Capability.valueOf(name).ordinal();
         for (int i = 0; i < optionalNames.length; i++)
         {

--- a/src/main/java/org/reaktivity/specification/nukleus/CoreFunctions.java
+++ b/src/main/java/org/reaktivity/specification/nukleus/CoreFunctions.java
@@ -87,7 +87,7 @@ public final class CoreFunctions
     @Function
     public static byte[] capabilities(String capability, String... optionalCapabilities)
     {
-        int capabilities = 0x00000000;
+        int capabilities = 0x00;
         capabilities = maskBits(capability, capabilities);
 
         for (int i = 0; i < optionalCapabilities.length; i++)
@@ -107,7 +107,7 @@ public final class CoreFunctions
         switch (capability)
         {
             case CHALLENGE_CAPABILITY:
-                capabilities = capabilities | 0x00000001;
+                capabilities = capabilities | 0x01;
                 break;
         }
         return capabilities;

--- a/src/main/java/org/reaktivity/specification/nukleus/CoreFunctions.java
+++ b/src/main/java/org/reaktivity/specification/nukleus/CoreFunctions.java
@@ -98,7 +98,9 @@ public final class CoreFunctions
         capabilityMask |= 1 << Capability.valueOf(name).ordinal();
         for (int i = 0; i < optionalNames.length; i++)
         {
-            capabilityMask |= 1 << Capability.valueOf(optionalNames[i]).ordinal();
+            final int capabilityOrdinal = Capability.valueOf(optionalNames[i]).ordinal();
+            assert capabilityOrdinal < Byte.SIZE;
+            capabilityMask |= 1 << capabilityOrdinal;
         }
         return capabilityMask;
     }

--- a/src/main/resources/META-INF/reaktivity/core.idl
+++ b/src/main/resources/META-INF/reaktivity/core.idl
@@ -161,6 +161,11 @@ scope core
             int64 signalId;
             octets extension;
         }
+
+        struct Challenge extends core::stream::Frame [0x40000004]
+        {
+            octets extension;
+        }
     }
 
     scope state

--- a/src/main/resources/META-INF/reaktivity/core.idl
+++ b/src/main/resources/META-INF/reaktivity/core.idl
@@ -163,7 +163,6 @@ scope core
 
         struct Challenge extends core::stream::Frame [0x40000004]
         {
-            int64 challengeId;
             octets extension;
         }
     }

--- a/src/main/resources/META-INF/reaktivity/core.idl
+++ b/src/main/resources/META-INF/reaktivity/core.idl
@@ -113,6 +113,7 @@ scope core
         struct Begin extends core::stream::Frame [0x00000001]
         {
             int64 affinity = 0;
+            uint8 capabilities = 0;
             octets extension;
         }
 
@@ -146,6 +147,7 @@ scope core
             int32 credit;
             int32 padding;
             int64 groupId;
+            uint8 capabilities = 0;
             octets extension;
         }
 

--- a/src/main/resources/META-INF/reaktivity/core.idl
+++ b/src/main/resources/META-INF/reaktivity/core.idl
@@ -19,16 +19,16 @@ scope core
     {
         enum Role
         {
-          SERVER,
-          CLIENT,
-          PROXY,
-          SERVER_REVERSE,
-          CLIENT_REVERSE
+            SERVER,
+            CLIENT,
+            PROXY,
+            SERVER_REVERSE,
+            CLIENT_REVERSE
         }
 
         enum Capability
         {
-          CHALLENGE
+            CHALLENGE
         }
 
         struct Command

--- a/src/main/resources/META-INF/reaktivity/core.idl
+++ b/src/main/resources/META-INF/reaktivity/core.idl
@@ -118,7 +118,6 @@ scope core
         struct Begin extends core::stream::Frame [0x00000001]
         {
             int64 affinity = 0;
-            uint8 capabilities = 0;
             octets extension;
         }
 
@@ -164,6 +163,7 @@ scope core
 
         struct Challenge extends core::stream::Frame [0x40000004]
         {
+            int64 challengeId;
             octets extension;
         }
     }

--- a/src/main/resources/META-INF/reaktivity/core.idl
+++ b/src/main/resources/META-INF/reaktivity/core.idl
@@ -26,6 +26,11 @@ scope core
           CLIENT_REVERSE
         }
 
+        enum Capability
+        {
+          CHALLENGE
+        }
+
         struct Command
         {
             int64 correlationId;

--- a/src/test/java/org/reaktivity/specification/nukleus/CoreFunctionsTest.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/CoreFunctionsTest.java
@@ -25,6 +25,8 @@ import org.junit.Test;
 import org.reaktivity.specification.nukleus.internal.types.String16FW;
 import org.reaktivity.specification.nukleus.internal.types.StringFW;
 
+import java.nio.ByteBuffer;
+
 public class CoreFunctionsTest
 {
     @Test
@@ -93,5 +95,14 @@ public class CoreFunctionsTest
         String16FW string = new String16FW().wrap(buffer, 0, buffer.capacity());
 
         assertEquals("", string.asString());
+    }
+
+    @Test
+    public void shouldMaskChallengeCapability()
+    {
+        final byte[] challengeMaskBytes = CoreFunctions.capabilities("CHALLENGE");
+        ByteBuffer bb = ByteBuffer.wrap(challengeMaskBytes);
+        final int challengeMask = bb.get();
+        assertEquals(0x01, challengeMask);
     }
 }

--- a/src/test/java/org/reaktivity/specification/nukleus/CoreFunctionsTest.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/CoreFunctionsTest.java
@@ -100,9 +100,7 @@ public class CoreFunctionsTest
     @Test
     public void shouldMaskChallengeCapability()
     {
-        final byte[] challengeMaskBytes = CoreFunctions.capabilities("CHALLENGE");
-        ByteBuffer bb = ByteBuffer.wrap(challengeMaskBytes);
-        final byte challengeMask = bb.get();
+        final byte challengeMask = CoreFunctions.capabilities("CHALLENGE");
         assertEquals(0x01, challengeMask);
     }
 }

--- a/src/test/java/org/reaktivity/specification/nukleus/CoreFunctionsTest.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/CoreFunctionsTest.java
@@ -25,8 +25,6 @@ import org.junit.Test;
 import org.reaktivity.specification.nukleus.internal.types.String16FW;
 import org.reaktivity.specification.nukleus.internal.types.StringFW;
 
-import java.nio.ByteBuffer;
-
 public class CoreFunctionsTest
 {
     @Test

--- a/src/test/java/org/reaktivity/specification/nukleus/CoreFunctionsTest.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/CoreFunctionsTest.java
@@ -102,7 +102,7 @@ public class CoreFunctionsTest
     {
         final byte[] challengeMaskBytes = CoreFunctions.capabilities("CHALLENGE");
         ByteBuffer bb = ByteBuffer.wrap(challengeMaskBytes);
-        final int challengeMask = bb.get();
+        final byte challengeMask = bb.get();
         assertEquals(0x01, challengeMask);
     }
 }


### PR DESCRIPTION
As well as a capabilities() function to allow BEGIN and WINDOW to have their capabilities set via a string representing the name of the capability: as of now only supports "challenge" = 0x01. 

Note: 
```
enum Signals(uint8)
{
    CHALLENGE(0x81)
}
```
has not been implemented yet.